### PR TITLE
make backup file location customizable

### DIFF
--- a/app/src/main/java/org/ebur/debitum/util/FileUtils.java
+++ b/app/src/main/java/org/ebur/debitum/util/FileUtils.java
@@ -213,4 +213,21 @@ public abstract class FileUtils {
 
         return destFile;
     }
+
+    // copies backup file from original location to one decided via SAF picker
+    public static void copyZip(File originalFile, Uri destUri, Context context) throws IOException {
+        ParcelFileDescriptor pfd = context.getContentResolver().openFileDescriptor(destUri, "w");
+        FileOutputStream destFos = new FileOutputStream(pfd.getFileDescriptor());
+        FileInputStream originalFis = new FileInputStream(originalFile);
+        FileChannel originalChannel = originalFis.getChannel();
+        FileChannel destChannel = destFos.getChannel();
+
+        originalChannel.transferTo(0, originalChannel.size(), destChannel);
+
+        destChannel.close();
+        originalChannel.close();
+        destFos.close();
+        originalFis.close();
+        pfd.close();
+    }
 }


### PR DESCRIPTION
In this PR, I changed the behavior of the "Backup data" button to open the Android file picker and create a file, and then copy the backup file from the original location to the user-picked one. This should enable users on Android 11+ to access backup file and closes #69.


The stuffs I haven't decided and done:

1. Should we delete the original backup file after copying it?
2. Changing the string on the "Backup data" button on Settings